### PR TITLE
ci: add workflow to update package versions in README.md

### DIFF
--- a/.github/workflows/update-readme-package-version.yaml
+++ b/.github/workflows/update-readme-package-version.yaml
@@ -6,7 +6,7 @@ jobs:
   update-readme-package-versions:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/update-readme-package-version.yaml
+++ b/.github/workflows/update-readme-package-version.yaml
@@ -1,0 +1,34 @@
+name: Update README.md Package Versions
+on:
+  workflow_dispatch:
+
+jobs:
+  update-readme-package-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Update README.md package Versions
+      id: update-readme-package-versions
+      run: |
+        pnpm install
+        node scripts/update-readme-package-versions.mjs
+        echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
+
+    - name: Create Pull Request
+      if: steps.update-readme-package-versions.outputs.has_changes == 'true'
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'chore: update package versions in README.md'
+        committer: GitHub Actions Bot <actions@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        branch: update-readme-package-versions
+        delete-branch: true
+        title: 'chore: update package versions in README.md'
+        body: |
+          This PR updates the biome package version in README.md to the latest version.

--- a/scripts/update-readme-package-versions.mjs
+++ b/scripts/update-readme-package-versions.mjs
@@ -1,0 +1,36 @@
+import fs from "fs";
+
+const getLatestPackageVersion = async (packageName) => {
+	const response = await fetch(
+		`https://registry.npmjs.org/${packageName}/latest`,
+	);
+	const data = await response.json();
+	return data.version;
+};
+
+const VERSION_REGEX = /(\d+\.\d+\.\d+)/g;
+
+const updateReadmePackageVersions = async (packageName, readmePath) => {
+	try {
+		const newVersion = await getLatestPackageVersion(packageName);
+		if (!newVersion) {
+			throw new Error(`Failed to get latest version of ${packageName}`);
+		}
+
+		const originalContent = fs.readFileSync(readmePath, "utf8");
+		const updatedContent = originalContent.replace(VERSION_REGEX, newVersion);
+
+		if (originalContent !== updatedContent) {
+			fs.writeFileSync(readmePath, updatedContent);
+			console.info(`Updated version in ${readmePath} to ${newVersion}`);
+			process.env.HAS_CHANGES = "true";
+		} else {
+			console.info(`No version changes needed in ${readmePath}`);
+			process.env.HAS_CHANGES = "false";
+		}
+	} catch (error) {
+		console.error("Failed to update", error);
+	}
+};
+
+updateReadmePackageVersions("@biomejs/biome", "README.md");


### PR DESCRIPTION
In README.md, we use `@biomejs/biome` specific version, but it's not updated constantly.
This PR creates a workflow (workflow_dispatch) to update the described versions.