### PR TITLE
ci: set minimum permissions for version update workflow

### DIFF
--- a/.github/workflows/update-readme-package-version.yaml
+++ b/.github/workflows/update-readme-package-version.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   update-readme-package-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - name: Setup Node.js


### PR DESCRIPTION
This PR sets minimum permissions to version update workflow. 