### PR TITLE
chore: remove `@biomejs/biome` from trustedDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
     },
   },
   "trustedDependencies": [
-    "@biomejs/biome",
     "lefthook",
   ],
   "packages": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 	},
 	"packageManager": "bun@1.2.10",
 	"trustedDependencies": [
-		"@biomejs/biome",
 		"lefthook"
 	]
 }


### PR DESCRIPTION
## Summary

Remove @biomejs/biome from the trustedDependencies list and regenerate the bun.lock file to reflect the change.

Chores:
- Remove @biomejs/biome from trustedDependencies in package.json
- Update bun.lock to reflect the removal

## Why?

"[chore: remove postinstall script @biomejs/biome #4887](https://github.com/biomejs/biome/pull/4887)" PR removed postinstall script.
So you don't need to add @biomejs/biome above v2 version to trustedDependencies anymore.