### PR TITLE
ci: automerge readme version updates

### DIFF
--- a/.github/workflows/update-readme-package-version.yaml
+++ b/.github/workflows/update-readme-package-version.yaml
@@ -26,6 +26,7 @@ jobs:
           bun scripts/update-readme-package-versions.ts
 
       - name: Create Pull Request
+        id: pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,3 +39,6 @@ jobs:
           body: |
             This PR updates the biome package version in README.md to the latest version.
           add-paths: README.md
+
+      - name: Auto-merge Pull Request
+        run: gh pr merge --auto "${{ steps.pr.outputs.pull-request-number }}"


### PR DESCRIPTION
From now on, the PRs that update the version of Biome in the readme will be automerged.

One less thing to worry about, and it's relatively low risk, in my opinion.